### PR TITLE
BUG: If VTK8 is used, use VTK_LIBRARIES configured in VTKConfig.cmake

### DIFF
--- a/Filters/CMakeLists.txt
+++ b/Filters/CMakeLists.txt
@@ -38,13 +38,21 @@ if(USE_OPENNI)
   list(APPEND headers vtkPCLOpenNISource.h)
 endif()
 
-set(VTK_LIBRARIES vtkFiltering vtkIO vtkGraphics)
+set(VTK_LIBRARIES
+  vtkInteractionWidgets
+  vtkInteractionStyle
+  vtkRenderingFreeType
+  vtkRenderingCore
+  vtkRendering${VTK_RENDERING_BACKEND}
+  vtkFiltersExtraction
+  vtkFiltersCore
+  vtkCommonCore
+  )
 
 set(deps
   ${PCL_LIBRARIES}
   ${VTK_LIBRARIES}
   )
-
 
 set(library_name vtkPCLFilters)
 


### PR DESCRIPTION
When using VTK8, the CMake variable VTK_LIBRARIES is already defined and lists
most VTK libraries. There is no need to manually define this variable. Some
Python VTK libraries are not listed in this CMake variable and need to
be manually listed for compilation on MacOS.