### PR TITLE
Remove INSTALL_NAME_DIR target property

### DIFF
--- a/Filters/CMakeLists.txt
+++ b/Filters/CMakeLists.txt
@@ -58,7 +58,6 @@ set(library_name vtkPCLFilters)
 
 add_library(${library_name} ${sources})
 target_link_libraries(${library_name} ${deps})
-set_target_properties(${library_name}  PROPERTIES INSTALL_NAME_DIR "${CMAKE_INSTALL_PREFIX}/lib")
 
 install(TARGETS ${library_name}
     RUNTIME DESTINATION bin


### PR DESCRIPTION
Using INSTALL_NAME_DIR target property forces the install name to be an
absolute path instead of `@rpath/{target_name}` [1]. This causes problems
when one tries to relocate the target once it is installed.
This patch removes this target property. If a project needs to keep
the absolute path, CMake variables such as INSTALL_NAME_DIR can be set at
configuration to do so.

[1] https://gitlab.kitware.com/cmake/cmake/issues/16589