### PR TITLE
Explicitly include vtkVersion.h in vtkAnnotateOBBs.cxx

### DIFF
--- a/Filters/vtkAnnotateOBBs.cxx
+++ b/Filters/vtkAnnotateOBBs.cxx
@@ -26,6 +26,7 @@
 #include "vtkThresholdPoints.h"
 #include "vtkOutlineSource.h"
 #include "vtkOBBTree.h"
+#include "vtkVersion.h"
 
 #include <Eigen/Geometry>
 


### PR DESCRIPTION
For whatever reason this wasn't showing up anymore in vtk installed
from drake master causing the check in RequestData to fail and leading
to a compile error.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/patmarion/pointcloudlibraryplugin/5)
<!-- Reviewable:end -->
